### PR TITLE
Add support to use meta field of a resource

### DIFF
--- a/.changes/unreleased/Features-20230525-221550.yaml
+++ b/.changes/unreleased/Features-20230525-221550.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add dbt meta to comment metadata
+time: 2023-05-25T22:15:50.19853+01:00
+custom:
+  Author: pratik60
+  PR: "13"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An example query comment contains:
     "node_id": "model.my_project.model_a",
     "node_resource_type": "model",
     "node_tags": ["tag_1", "tag_2"],
+    "node_meta": {"owner": "@alice", "model_maturity": "in dev"},
     "materialized": "incremental",
 
     -- dbt Cloud only

--- a/integration_test_project/models/materialized_table.sql
+++ b/integration_test_project/models/materialized_table.sql
@@ -1,3 +1,12 @@
-{{ config(materialized='table', tags='a') }}
+{{
+    config(
+        meta={
+            "owner": "@alice", 
+            "model_maturity": "in dev"
+        },
+        materialized="table",
+        tags='a'
+    )
+}}
 
 select 1 as a

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -21,6 +21,7 @@
             node_schema=node.schema,
             node_id=node.unique_id,
             node_resource_type=node.resource_type,
+            node_meta=node.config.meta,
             node_tags=node.tags,
         ) -%}
 


### PR DESCRIPTION
From: https://docs.getdbt.com/reference/resource-configs/meta

The meta field can store custom information about a model which would be useful metadata to add to query tags to filter data. My usecase is to filter query by team owner and associate cost accordingly.

I verified this with "meta" being empty for a model, which would generate an empty {}. If meta is populated, it would use that in the query tag.