### PR TITLE
Add support for query tags from profiles.yml and environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ select ...
 ```
 
 Additionaly, you can set the query_tag in the profiles.yml:
+
 profiles.yml
 ```yml
 default:
@@ -131,6 +132,7 @@ default:
 Another option is to use the optional project variable `env_vars_to_query_tag_list` that will have a list of environment variables to create the query tags from.
 
 Example:
+
 dbt_project.yml:
 ```yml
   vars:

--- a/README.md
+++ b/README.md
@@ -117,9 +117,28 @@ Model
 select ...
 ```
 
+Additionaly, you can set the query_tag in the profiles.yml:
+profiles.yml
+```yml
+default:
+  outputs:
+    dev:
+      query_tag: '{"team": "data"}'
+      ...
+  target: dev
+```
+
+Another option is to use the optional project variable `env_vars_to_query_tag_list` that will have a list of environment variables to create the query tags from.
+
+Example:
+dbt_project.yml:
+```yml
+  vars:
+    env_vars_to_query_tag_list: ['TEAM','JOB_NAME']
+```
 Results in a final query tag of
 ```
-'{"team": "data", "app": "dbt", "dbt_snowflake_query_tags_version": "2.3.1", "is_incremental": true}'
+'{"team": "data", "job_name": "daily", "app": "dbt", "dbt_snowflake_query_tags_version": "2.3.1", "is_incremental": true}'
 ```
 
 the additional information is added by this package.

--- a/macros/query_tags.sql
+++ b/macros/query_tags.sql
@@ -3,6 +3,27 @@
 {%- endmacro %}
 
 {% macro default__set_query_tag() -%}
+    {# Get session level query tag #}
+    {% set session_query_tag = get_current_query_tag() %}
+    {% set session_query_tag_json = {} %}
+
+    {% if session_query_tag %}
+        {% if fromjson(session_query_tag) is mapping %}
+            {% set session_query_tag_json = fromjson(session_query_tag) %}
+        {% else %}
+            {% do log("dbt-snowflake-query-tags warning: the session level query tag value of '{}' is not a mapping type, so is being ignored. If you'd like to add additional query tag information, use a mapping type instead, or remove it to avoid this message.".format(session_query_tag), True) %}
+        {% endif %}
+    {% endif %}
+
+    {# The env_vars_to_query_tag_list should contain an environment variables list to construct query tag dict #}
+    {% set env_var_query_tags = {} %}
+    {% if var('env_vars_to_query_tag_list', '') %} {# Get a list of env vars from env_vars_to_query_tag_list variable to add additional query tags #}
+        {% for k in var('env_vars_to_query_tag_list') %}
+            {% set v = env_var(k, '') %}
+            {% do env_var_query_tags.update({k.lower(): v}) if v %}
+        {% endfor %}
+    {% endif %}
+
     {# Start with any model-configured dict #}
     {% set query_tag = config.get('query_tag', default={}) %}
 
@@ -11,6 +32,8 @@
     {% set query_tag = {} %} {# If the user has set the query tag config as a non mapping type, start fresh #}
     {% endif %}
 
+    {% do query_tag.update(session_query_tag_json) %}
+    {% do query_tag.update(env_var_query_tags) %}
 
     {%- do query_tag.update(
         app='dbt',


### PR DESCRIPTION
Currently if I want to extend the query tags, only the ones from the model's config are added.
If I have a query tag in my connection profile in the `profiles.yml` file - they are ignored.

I've added they support to fetch the query tag from `profiles.yml` file as well as from environment variables.

The list of the environment variables to get the tags from is defined by a new project variable: `env_vars_to_query_tag_list`.

