### PR TITLE
Query tag node name

### DIFF
--- a/.changes/unreleased/Features-20240424-172713.yaml
+++ b/.changes/unreleased/Features-20240424-172713.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added model_name to default query tags
+time: 2024-04-24T17:27:13.894775-06:00
+custom:
+  Author: jnschurig
+  PR: "25"

--- a/macros/query_tags.sql
+++ b/macros/query_tags.sql
@@ -36,6 +36,7 @@
     {%- do query_tag.update(
         app='dbt',
         dbt_snowflake_query_tags_version='2.3.3',
+        node=model.name,
     ) -%}
 
     {% if thread_id %}

--- a/macros/query_tags.sql
+++ b/macros/query_tags.sql
@@ -36,7 +36,7 @@
     {%- do query_tag.update(
         app='dbt',
         dbt_snowflake_query_tags_version='2.3.3',
-        node=model.name,
+        node_name=model.name,
     ) -%}
 
     {% if thread_id %}


### PR DESCRIPTION
# Add model name to base query tag

In any model in which a query tag is valuable, node name is also very helpful. While the node name is already in the query comment, it's quite large and can clutter up the sql quite a bit. Having the model name in the query tag (rather than only in query comment) also improves speed and reliability of parsing the node name successfully.