### PR TITLE
Adding run_started_at to query comment

### DIFF
--- a/.changes/unreleased/Features-20240506-131218.yaml
+++ b/.changes/unreleased/Features-20240506-131218.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add run_started_at to query comment
+time: 2024-05-06T13:12:18.799857+10:00
+custom:
+  Author: bisset-a
+  PR: "27"

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -23,6 +23,7 @@
             node_resource_type=node.resource_type,
             node_meta=node.config.meta,
             node_tags=node.tags,
+            run_started_at=run_started_at.strftime("%Y-%m-%d %H:%M:%S"),
             full_refresh=flags.FULL_REFRESH,
             which=flags.WHICH,
         ) -%}

--- a/macros/query_comment.sql
+++ b/macros/query_comment.sql
@@ -23,7 +23,7 @@
             node_resource_type=node.resource_type,
             node_meta=node.config.meta,
             node_tags=node.tags,
-            run_started_at=run_started_at.strftime("%Y-%m-%d %H:%M:%S"),
+            run_started_at=run_started_at.astimezone(modules.pytz.utc).isoformat(),
             full_refresh=flags.FULL_REFRESH,
             which=flags.WHICH,
         ) -%}


### PR DESCRIPTION
Adding `run_started_at` to the query comment